### PR TITLE
randomForest package now imported into namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+FIEmspro.Rproj

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -52,8 +52,8 @@ S3method(print, mc.summary)
 import(graphics)
 import(stats)
 import(e1071)
+import(randomForest)
 
 ## import(ncdf) ## no namespace
 ## import(MASS)
 ## import(impute)
-## import(randomForest)


### PR DESCRIPTION
importing the randomForest package in the namespace allows accest to be used in parallel without having to export the functions using clusterExport.